### PR TITLE
Why rustycli exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 <br>
 
 [`rustycli`](https://github.com/pwnwriter/rustycli) is a tool, allowing you to access the [`rust playground`](https://play.rust-lang.org/) right in the terminal and retaining all the features available on the web version.
+
+Why? For being able to play with Rust on low resource systems.
+Systems such as you find in poor funded schools.
 ![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/aqua.png)
 
 


### PR DESCRIPTION
Qoutes from https://www.reddit.com/r/rust/comments/15a2c7q/access_the_rust_playground_right_in_terminal/

  I had to teach some of my school friends rust, while I had a very tough
  time setting up rust on the machines with very low ram and storage,

  So, I wanted to make something that can do everything rustc does, but
  without opening the browser. Thats how I ended up creating rustycli. Now
  I can run rust on any machine by downloading the binary from releases
  of rustycli. I'm currently working to make binary available for all
  the major architecture.

  We study in government school, and we are limited with our hardware
  specs to only 2gigs of RAM and i3. I've installed my custom distro
  metislinux from https://metislinux.org in computers which me and
  my friends use. And also, there we are using very minimal things,
  a browser would even make the fan go brrrrr.